### PR TITLE
Specify wrapper stylesheet create function via settings

### DIFF
--- a/src/rules/no-undef-styles.coffee
+++ b/src/rules/no-undef-styles.coffee
@@ -14,9 +14,11 @@ module.exports =
     hasSeenStylesDeclaration = no
 
     VariableDeclarator: (node) ->
-      return unless isStylesDeclaration node
+      isDeclaration = isStylesDeclaration {node, context}
+      return unless isDeclaration
       hasSeenStylesDeclaration = yes
-      styleKeys = (key.name for {key, computed} in node.init.properties when key.type is 'Identifier' and not computed)
+      {styleKeys} = isDeclaration
+      styleKeys = (key.name for key in styleKeys)
 
     MemberExpression: (node) ->
       return unless isStyleReference node

--- a/src/rules/no-undef-styles.coffee
+++ b/src/rules/no-undef-styles.coffee
@@ -11,9 +11,11 @@ module.exports =
   create: (context) ->
     styleKeys = null
     styleReferences = []
+    hasSeenStylesDeclaration = no
 
     VariableDeclarator: (node) ->
       return unless isStylesDeclaration node
+      hasSeenStylesDeclaration = yes
       styleKeys = (key.name for {key, computed} in node.init.properties when key.type is 'Identifier' and not computed)
 
     MemberExpression: (node) ->
@@ -21,7 +23,7 @@ module.exports =
       styleReferences.push node.property
 
     'Program:exit': ->
-      return unless styleKeys?.length
+      return unless hasSeenStylesDeclaration
       for reference in styleReferences
         continue if reference.name in styleKeys
         context.report reference, "Undefined style detected: #{reference.name}"

--- a/src/rules/no-unused-styles.coffee
+++ b/src/rules/no-unused-styles.coffee
@@ -13,8 +13,9 @@ module.exports =
     styleReferences = []
 
     VariableDeclarator: (node) ->
-      return unless isStylesDeclaration node
-      styleKeys = (key for {key, computed} in node.init.properties when key.type is 'Identifier' and not computed)
+      isDeclaration = isStylesDeclaration {node, context}
+      return unless isDeclaration
+      {styleKeys} = isDeclaration
 
     MemberExpression: (node) ->
       return unless isStyleReference node

--- a/src/tests/rules/no-undef-styles.coffee
+++ b/src/tests/rules/no-undef-styles.coffee
@@ -42,6 +42,26 @@ tests =
       const styles = {}
     '''
     errors: [error('a')]
+  ,
+    # stylesheet-create-function
+    code: '''
+      render(<div css={styles.a} />)
+
+      const styles = createStylesheet({b: 1})
+    '''
+    errors: [error('a')]
+    settings:
+      'styles-object/stylesheet-create-function': 'createStylesheet'
+  ,
+    # stylesheet-create-function member expression
+    code: '''
+      render(<div css={styles.a} />)
+
+      const styles = StyleSheet.create({b: 1})
+    '''
+    errors: [error('a')]
+    settings:
+      'styles-object/stylesheet-create-function': 'StyleSheet.create'
   ]
 
 config =

--- a/src/tests/rules/no-undef-styles.coffee
+++ b/src/tests/rules/no-undef-styles.coffee
@@ -34,6 +34,14 @@ tests =
       const styles = {b: 1}
     '''
     errors: [error('a')]
+  ,
+    # empty styles object
+    code: '''
+      render(<div css={styles.a} />)
+
+      const styles = {}
+    '''
+    errors: [error('a')]
   ]
 
 config =

--- a/src/tests/rules/no-unused-styles.coffee
+++ b/src/tests/rules/no-unused-styles.coffee
@@ -36,6 +36,26 @@ tests =
       render(<div css={styles.ab} />)
     '''
     errors: [error('a')]
+  ,
+    # stylesheet-create-function
+    code: '''
+      render(<div css={styles.ab} />)
+
+      const styles = createStylesheet({a: 1})
+    '''
+    errors: [error('a')]
+    settings:
+      'styles-object/stylesheet-create-function': 'createStylesheet'
+  ,
+    # stylesheet-create-function member expression
+    code: '''
+      render(<div css={styles.ab} />)
+
+      const styles = StyleSheet.create({a: 1})
+    '''
+    errors: [error('a')]
+    settings:
+      'styles-object/stylesheet-create-function': 'StyleSheet.create'
   ]
 
 config =

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,7 +1,33 @@
-isStylesDeclaration = (node) ->
-  return no unless node.id.name is 'styles'
-  return no unless node.init.type is 'ObjectExpression'
+getStyleKeys = (stylesObject) ->
+  key for {key, computed} in stylesObject.properties when key.type is 'Identifier' and not computed
+
+isStylesheetCreateFunction = ({callee, stylesheetCreateFunction}) ->
+  memberExpressionParts = stylesheetCreateFunction.split '.'
+  currentMemberExpression = callee
+  while memberExpressionParts.length
+    if memberExpressionParts.length is 1
+      return no unless currentMemberExpression.type is 'Identifier'
+      property = currentMemberExpression
+      object = null
+    else
+      return no unless currentMemberExpression.type is 'MemberExpression'
+      {object, property} = currentMemberExpression
+    return no unless property.type is 'Identifier'
+    currentPart = memberExpressionParts.pop()
+    return no unless currentPart is property.name
+    currentMemberExpression = object
   yes
+
+isStylesDeclaration = ({node, context: {settings}}) ->
+  return no unless node?.id?.name is 'styles'
+  {init} = node
+  return {styleKeys: getStyleKeys(init)} if init.type is 'ObjectExpression'
+  return no unless init.type is 'CallExpression'
+  return no unless stylesheetCreateFunction = settings['styles-object/stylesheet-create-function']
+  {callee, arguments: args} = init
+  return no unless isStylesheetCreateFunction {callee, stylesheetCreateFunction}
+  return no unless args[0]?.type is 'ObjectExpression'
+  styleKeys: getStyleKeys(args[0])
 
 isStyleReference = (node) ->
   return no unless node.object.name is 'styles'


### PR DESCRIPTION
In this PR:
- allow setting `styles-object/stylesheet-create-function` in ESLint `settings` to specify a stylesheet create wrapper function name (eg `createStylesheet({...})`, `StyleSheet.create({...})`)